### PR TITLE
Add getaddresses fn to pair

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -21,6 +21,17 @@ export enum Rounding {
 
 export const FACTORY_ADDRESS = '0xEF45d134b73241eDa7703fa787148D9C9F4950b0'
 
+export const FACTORIES = [
+  {
+    address: '0xEF45d134b73241eDa7703fa787148D9C9F4950b0',
+    init_code_hash: '0xe242e798f6cee26a9cb0bbf24653bf066e5356ffeac160907fe2cc108e238617',
+  },
+  {
+    address: '0x152eE697f2E276fA89E96742e9bB9aB1F2E61bE3',
+    init_code_hash: '0xcdf2deca40a0bd56de8e3ce5c7df6727e5b1bf2ac96f283fa9c4b3e6b42ea9d2',
+  },
+]
+
 export const INIT_CODE_HASH = '0xe242e798f6cee26a9cb0bbf24653bf066e5356ffeac160907fe2cc108e238617'
 
 export const MINIMUM_LIQUIDITY = JSBI.BigInt(1000)

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,12 +24,12 @@ export const FACTORY_ADDRESS = '0xEF45d134b73241eDa7703fa787148D9C9F4950b0'
 export const FACTORIES = [
   {
     address: '0xEF45d134b73241eDa7703fa787148D9C9F4950b0',
-    init_code_hash: '0xe242e798f6cee26a9cb0bbf24653bf066e5356ffeac160907fe2cc108e238617',
+    init_code_hash: '0xe242e798f6cee26a9cb0bbf24653bf066e5356ffeac160907fe2cc108e238617'
   },
   {
     address: '0x152eE697f2E276fA89E96742e9bB9aB1F2E61bE3',
-    init_code_hash: '0xcdf2deca40a0bd56de8e3ce5c7df6727e5b1bf2ac96f283fa9c4b3e6b42ea9d2',
-  },
+    init_code_hash: '0xcdf2deca40a0bd56de8e3ce5c7df6727e5b1bf2ac96f283fa9c4b3e6b42ea9d2'
+  }
 ]
 
 export const INIT_CODE_HASH = '0xe242e798f6cee26a9cb0bbf24653bf066e5356ffeac160907fe2cc108e238617'

--- a/src/entities/pair.ts
+++ b/src/entities/pair.ts
@@ -58,11 +58,13 @@ export class Pair {
         ...PAIR_ADDRESSES_CACHE,
         [tokens[0].address]: {
           ...PAIR_ADDRESSES_CACHE?.[tokens[0].address],
-          [tokens[1].address]: FACTORIES.map(f => getCreate2Address(
-            f.address,
-            keccak256(['bytes'], [pack(['address', 'address'], [tokens[0].address, tokens[1].address])]),
-            f.init_code_hash
-          ))
+          [tokens[1].address]: FACTORIES.map(f =>
+            getCreate2Address(
+              f.address,
+              keccak256(['bytes'], [pack(['address', 'address'], [tokens[0].address, tokens[1].address])]),
+              f.init_code_hash
+            )
+          )
         }
       }
     }


### PR DESCRIPTION
Made the changes additive leaving existing logic in place, just added what I needed for the new function, which will support returning the addresses for pairs on multiple dexes, for liquidity migration 