### PR TITLE
ChainId consistency with spookyswap

### DIFF
--- a/dist/constants.d.ts
+++ b/dist/constants.d.ts
@@ -2,7 +2,9 @@ import JSBI from 'jsbi';
 export declare type BigintIsh = JSBI | bigint | string;
 export declare enum ChainId {
     MAINNET = 250,
-    FTMTESTNET = 4002
+    FTMTESTNET = 4002,
+    ETHMAINNET = 1,
+    BSC = 56
 }
 export declare enum TradeType {
     EXACT_INPUT = 0,


### PR DESCRIPTION
This does not seems to be inline with SpookySwap and builds are failing.

`5:28:18 PM: Creating an optimized production build...
5:30:46 PM: Failed to compile.
5:30:46 PM: 
5:30:46 PM: /opt/build/repo/src/tomb-finance/TombFinance.ts
5:30:46 PM: TypeScript error in /opt/build/repo/src/tomb-finance/TombFinance.ts(547,34):
5:30:46 PM: Argument of type 'import("/opt/build/repo/node_modules/@spookyswap/sdk/dist/constants").ChainId' is not assignable to parameter of type 'import("/opt/build/repo/node_modules/@spiritswap/sdk/dist/constants").ChainId'.
5:30:46 PM:   Property 'ETHMAINNET' is missing in type 'import("/opt/build/repo/node_modules/@spiritswap/sdk/dist/constants").ChainId'.  TS2345
5:30:46 PM:     545 |     const { WFTM } = this.externalTokens;
5:30:46 PM:     546 | 
5:30:46 PM:   > 547 |     const wftm = new TokenSpirit(chainId, WFTM.address, WFTM.decimal);
5:30:46 PM:         |                                  ^
5:30:46 PM:     548 |     const token = new TokenSpirit(chainId, tokenContract.address, tokenContract.decimal, tokenContract.symbol);
5:30:46 PM:     549 |     try {
5:30:46 PM:     550 |       const wftmToToken = await FetcherSpirit.fetchPairData(wftm, token, this.provider);
5:30:46 PM: error Command failed with exit code 1.
5:30:46 PM: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.`